### PR TITLE
refactor: migrate to use upstream GraphQL

### DIFF
--- a/customtypes/id.go
+++ b/customtypes/id.go
@@ -3,14 +3,12 @@ package customtypes
 import (
 	"errors"
 	"strconv"
+
+	graphql "github.com/graph-gophers/graphql-go"
 )
 
 // ID represents GraphQL's "ID" scalar type. A custom type may be used instead.
-type ID string
-
-func (ID) ImplementsGraphQLType(name string) bool {
-	return name == "ID"
-}
+type ID graphql.ID
 
 func (id *ID) UnmarshalGraphQL(input interface{}) error {
 	var err error
@@ -23,8 +21,4 @@ func (id *ID) UnmarshalGraphQL(input interface{}) error {
 		err = errors.New("wrong type")
 	}
 	return err
-}
-
-func (id ID) MarshalJSON() ([]byte, error) {
-	return strconv.AppendQuote(nil, string(id)), nil
 }

--- a/customtypes/time.go
+++ b/customtypes/time.go
@@ -1,22 +1,13 @@
 package customtypes
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
+
+	graphql "github.com/graph-gophers/graphql-go"
 )
 
-// Time is a custom GraphQL type to represent an instant in time. It has to be added to a schema
-// via "scalar Time" since it is not a predeclared GraphQL type like "ID".
-type Time struct {
-	time.Time
-}
-
-// ImplementsGraphQLType maps this custom Go type
-// to the graphql scalar type in the schema.
-func (Time) ImplementsGraphQLType(name string) bool {
-	return name == "Time"
-}
+type Time graphql.Time
 
 // UnmarshalGraphQL is a custom unmarshaler for Time
 //
@@ -40,12 +31,4 @@ func (t *Time) UnmarshalGraphQL(input interface{}) error {
 	default:
 		return fmt.Errorf("wrong type")
 	}
-}
-
-// MarshalJSON is a custom marshaler for Time
-//
-// This function will be called whenever you
-// query for fields that use the Time type
-func (t Time) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.Time)
 }

--- a/engine.go
+++ b/engine.go
@@ -13,6 +13,7 @@ import (
 	"github.com/chirino/graphql/resolvers"
 	"github.com/chirino/graphql/schema"
 	"github.com/chirino/graphql/trace"
+	upgraphql "github.com/graph-gophers/graphql-go"
 )
 
 type Engine struct {
@@ -142,7 +143,9 @@ func (engine *Engine) ServeGraphQLStream(request *Request) ResponseStream {
 		TryCast:        engine.TryCast,
 		FireSubscriptionEventFunc: func(d json.RawMessage, e qerrors.ErrorList) {
 			responses <- &Response{
-				Data:   d,
+				Response: &upgraphql.Response {
+					Data:   d,
+				},
 				Errors: e,
 			}
 			traceResponse(e)

--- a/error.go
+++ b/error.go
@@ -12,5 +12,5 @@ func NewError(message string) *Error {
 }
 
 func Errorf(format string, a ...interface{}) *Error {
-	return qerrors.Errorf(format, a...)
+	return qerrors.New(format, a...)
 }

--- a/exec/field_selection.go
+++ b/exec/field_selection.go
@@ -52,7 +52,7 @@ func (c FieldSelectionContext) Apply(selections []schema.Selection) (result []Fi
 
 			field := fields.Get(selection.Name)
 			if field == nil {
-				errs = append(errs, qerrors2.Errorf("field '%s' not found on '%s': ", selection.Name, c.OnType.String()))
+				errs = append(errs, qerrors2.New("field '%s' not found on '%s': ", selection.Name, c.OnType.String()))
 			} else {
 				selection.Schema = &schema.FieldSchema{
 					Field:  field,

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/friendsofgo/graphiql v0.2.2
 	github.com/gorilla/websocket v1.4.2
+	github.com/graph-gophers/graphql-go v0.0.0-20210319060855-d2656e8bde15
 	github.com/josharian/intern v1.0.0
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/friendsofgo/graphiql v0.2.2 h1:ccnuxpjgIkB+Lr9YB2ZouiZm7wvciSfqwpa9ug
 github.com/friendsofgo/graphiql v0.2.2/go.mod h1:8Y2kZ36AoTGWs78+VRpvATyt3LJBx0SZXmay80ZTRWo=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/graph-gophers/graphql-go v0.0.0-20210319060855-d2656e8bde15 h1:ys+YCFVAWiVMaaZQ2nNtSwmYTaqdw1d+rpw04JJmIWE=
+github.com/graph-gophers/graphql-go v0.0.0-20210319060855-d2656e8bde15/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
@@ -21,7 +23,6 @@ github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 h1:bUGsEnyNbVPw06B
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd h1:ug7PpSOB5RBPK1Kg6qskGBoP3Vnj/aNYFTznWvlkGo0=
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
@@ -37,7 +38,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -48,7 +48,6 @@ golang.org/x/tools v0.0.0-20200128220307-520188d60f50/go.mod h1:TB2adYChydJhpapK
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/httpgql/http-client.go
+++ b/httpgql/http-client.go
@@ -69,5 +69,5 @@ func (client *Client) ServeGraphQL(request *graphql.Request) *graphql.Response {
 	}
 
 	preview, _ := ioutil.ReadAll(io.LimitReader(resp.Body, 1024))
-	return response.AddError(qerrors.Errorf("invalid content type: %s", contentType).WithCause(errors.New(string(preview))))
+	return response.AddError(qerrors.New("invalid content type: %s", contentType).WithCause(errors.New(string(preview))))
 }

--- a/httpgql/http_test.go
+++ b/httpgql/http_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/chirino/graphql"
 	"github.com/chirino/graphql/internal/example/starwars"
+	upgraphql "github.com/graph-gophers/graphql-go"
 )
 
 func TestEngineAPIServeHTTP(t *testing.T) {
@@ -38,7 +39,9 @@ func TestClientServeGraphQL(t *testing.T) {
 	s := httptest.NewServer(&httpgql.Handler{
 		ServeGraphQL: func(request *graphql.Request) *graphql.Response {
 			return &graphql.Response{
-				Data: json.RawMessage(`{"hello":"world"}`),
+				Response: &upgraphql.Response {
+					Data: json.RawMessage(`{"hello":"world"}`),
+				},
 			}
 		},
 	})

--- a/httpgql/marshal.go
+++ b/httpgql/marshal.go
@@ -37,7 +37,7 @@ func UnmarshalSpec(id customtypes.ID, v interface{}) error {
 	}
 	i := strings.IndexByte(string(s), ':')
 	if i == -1 {
-		return qerrors.Errorf("invalid graphql.ID")
+		return qerrors.New("invalid graphql.ID")
 	}
 	return json.Unmarshal([]byte(s[i+1:]), v)
 }

--- a/httpgql/ws_test.go
+++ b/httpgql/ws_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/chirino/graphql"
 	"github.com/chirino/graphql/httpgql"
+	upgraphql "github.com/graph-gophers/graphql-go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,10 +27,14 @@ func TestClientServeGraphQLStream(t *testing.T) {
 		ServeGraphQLStream: func(request *graphql.Request) graphql.ResponseStream {
 			result := make(chan *graphql.Response, 2)
 			result <- &graphql.Response{
-				Data: json.RawMessage(`{"hello":"world"}`),
+				Response: &upgraphql.Response {
+					Data: json.RawMessage(`{"hello":"world"}`),
+				},
 			}
 			result <- &graphql.Response{
-				Data: json.RawMessage(`{"bye":"world"}`),
+				Response: &upgraphql.Response {
+					Data: json.RawMessage(`{"bye":"world"}`),
+				},
 			}
 			close(result)
 			return result

--- a/internal/exec/packer/packer.go
+++ b/internal/exec/packer/packer.go
@@ -215,7 +215,7 @@ type structPackerField struct {
 
 func (p *StructPacker) Pack(value interface{}) (reflect.Value, error) {
 	if value == nil {
-		return reflect.Value{}, qerrors.Errorf("got null for non-null")
+		return reflect.Value{}, qerrors.New("got null for non-null")
 	}
 
 	values := value.(map[string]interface{})
@@ -289,7 +289,7 @@ type ValuePacker struct {
 
 func (p *ValuePacker) Pack(value interface{}) (reflect.Value, error) {
 	if value == nil {
-		return reflect.Value{}, qerrors.Errorf("got null for non-null")
+		return reflect.Value{}, qerrors.New("got null for non-null")
 	}
 
 	coerced, err := unmarshalInput(p.ValueType, value)
@@ -305,7 +305,7 @@ type unmarshalerPacker struct {
 
 func (p *unmarshalerPacker) Pack(value interface{}) (reflect.Value, error) {
 	if value == nil {
-		return reflect.Value{}, qerrors.Errorf("got null for non-null")
+		return reflect.Value{}, qerrors.New("got null for non-null")
 	}
 
 	v := reflect.New(p.ValueType)

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/chirino/graphql/internal/scanner"
 	"github.com/chirino/graphql/qerrors"
+	uperrors "github.com/graph-gophers/graphql-go/errors"
 
 	"strconv"
 	"strings"
 )
 
 type syntaxError string
-type Location = qerrors.Location
+type Location = uperrors.Location
 
 type Lexer struct {
 	sc               scanner.Scanner
@@ -40,7 +41,7 @@ func (l *Lexer) CatchSyntaxError(f func()) (errRes error) {
 	defer func() {
 		if err := recover(); err != nil {
 			if err, ok := err.(syntaxError); ok {
-				errRes = qerrors.Errorf("syntax error: %s", err).WithLocations(l.Location())
+				errRes = qerrors.New("syntax error: %s", err).WithLocations(l.Location())
 				return
 			}
 			panic(err)

--- a/response.go
+++ b/response.go
@@ -1,16 +1,16 @@
 package graphql
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/chirino/graphql/qerrors"
+	upgraphql "github.com/graph-gophers/graphql-go"
 )
 
 // Response represents a typical response of a GraphQL server. It may be encoded to JSON directly or
 // it may be further processed to a custom response type, for example to include custom error data.
 type Response struct {
-	Data       json.RawMessage        `json:"data,omitempty"`
+	*upgraphql.Response
 	Errors     ErrorList              `json:"errors,omitempty"`
 	Extensions interface{}            `json:"extensions,omitempty"`
 	Details    map[string]interface{} `json:"-"`

--- a/schema/literals.go
+++ b/schema/literals.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/chirino/graphql/internal/lexer"
 	"github.com/chirino/graphql/internal/scanner"
-	"github.com/chirino/graphql/qerrors"
+	uperrors "github.com/graph-gophers/graphql-go/errors"
 
 	"io"
 	"strconv"
@@ -15,14 +15,14 @@ import (
 type Literal interface {
 	Evaluate(vars map[string]interface{}) interface{}
 	String() string
-	Location() qerrors.Location
+	Location() uperrors.Location
 	WriteTo(out io.StringWriter)
 }
 
 type BasicLit struct {
 	Type rune
 	Text string
-	Loc  qerrors.Location
+	Loc  uperrors.Location
 }
 
 func ToLiteral(v interface{}) Literal {
@@ -113,13 +113,13 @@ func (lit *BasicLit) String() string {
 	return lit.Text
 }
 
-func (lit *BasicLit) Location() qerrors.Location {
+func (lit *BasicLit) Location() uperrors.Location {
 	return lit.Loc
 }
 
 type ListLit struct {
 	Entries []Literal
-	Loc     qerrors.Location
+	Loc     uperrors.Location
 }
 
 func (lit *ListLit) Evaluate(vars map[string]interface{}) interface{} {
@@ -138,13 +138,13 @@ func (lit *ListLit) String() string {
 	return "[" + strings.Join(entries, ", ") + "]"
 }
 
-func (lit *ListLit) Location() qerrors.Location {
+func (lit *ListLit) Location() uperrors.Location {
 	return lit.Loc
 }
 
 type ObjectLit struct {
 	Fields []*ObjectLitField
-	Loc    qerrors.Location
+	Loc    uperrors.Location
 }
 
 type ObjectLitField struct {
@@ -169,12 +169,12 @@ func (lit *ObjectLit) String() string {
 	return "{" + strings.Join(entries, ", ") + "}"
 }
 
-func (lit *ObjectLit) Location() qerrors.Location {
+func (lit *ObjectLit) Location() uperrors.Location {
 	return lit.Loc
 }
 
 type NullLit struct {
-	Loc qerrors.Location
+	Loc uperrors.Location
 }
 
 func (lit *NullLit) Evaluate(vars map[string]interface{}) interface{} {
@@ -185,13 +185,13 @@ func (lit *NullLit) String() string {
 	return "null"
 }
 
-func (lit *NullLit) Location() qerrors.Location {
+func (lit *NullLit) Location() uperrors.Location {
 	return lit.Loc
 }
 
 type Variable struct {
 	Name string
-	Loc  qerrors.Location
+	Loc  uperrors.Location
 }
 
 func (v Variable) Evaluate(vars map[string]interface{}) interface{} {
@@ -202,7 +202,7 @@ func (v Variable) String() string {
 	return "$" + v.Name
 }
 
-func (v *Variable) Location() qerrors.Location {
+func (v *Variable) Location() uperrors.Location {
 	return v.Loc
 }
 

--- a/schema/query.go
+++ b/schema/query.go
@@ -6,7 +6,7 @@ import (
 	"text/scanner"
 
 	"github.com/chirino/graphql/internal/lexer"
-	"github.com/chirino/graphql/qerrors"
+	uperrors "github.com/graph-gophers/graphql-go/errors"
 )
 
 type QueryDocument struct {
@@ -45,7 +45,7 @@ type Operation struct {
 	Vars       InputValueList
 	Selections SelectionList
 	Directives DirectiveList
-	Loc        qerrors.Location
+	Loc        uperrors.Location
 }
 
 type Fragment struct {
@@ -58,14 +58,14 @@ type FragmentDecl struct {
 	Name       string
 	NameLoc    Location
 	Directives DirectiveList
-	Loc        qerrors.Location
+	Loc        uperrors.Location
 }
 
 type Selection interface {
 	Formatter
 	GetSelections(doc *QueryDocument) SelectionList
 	SetSelections(doc *QueryDocument, v SelectionList)
-	Location() qerrors.Location
+	Location() uperrors.Location
 }
 
 type FieldSelection struct {
@@ -76,7 +76,7 @@ type FieldSelection struct {
 	Arguments       ArgumentList
 	Directives      DirectiveList
 	Selections      SelectionList
-	SelectionSetLoc qerrors.Location
+	SelectionSetLoc uperrors.Location
 	Schema          *FieldSchema
 	Extension       interface{}
 }
@@ -89,14 +89,14 @@ type FieldSchema struct {
 type InlineFragment struct {
 	Fragment
 	Directives DirectiveList
-	Loc        qerrors.Location
+	Loc        uperrors.Location
 }
 
 type FragmentSpread struct {
 	Name       string
 	NameLoc    Location
 	Directives DirectiveList
-	Loc        qerrors.Location
+	Loc        uperrors.Location
 }
 
 func (t *Operation) SetSelections(doc *QueryDocument, v SelectionList)      { t.Selections = v }
@@ -121,10 +121,10 @@ func (t FragmentSpread) GetSelections(doc *QueryDocument) SelectionList {
 	return frag.Selections
 }
 
-func (t Operation) Location() qerrors.Location      { return t.Loc }
-func (t FieldSelection) Location() qerrors.Location { return t.NameLoc }
-func (t InlineFragment) Location() qerrors.Location { return t.Loc }
-func (t FragmentSpread) Location() qerrors.Location { return t.Loc }
+func (t Operation) Location() uperrors.Location      { return t.Loc }
+func (t FieldSelection) Location() uperrors.Location { return t.NameLoc }
+func (t InlineFragment) Location() uperrors.Location { return t.Loc }
+func (t FragmentSpread) Location() uperrors.Location { return t.Loc }
 
 func (doc *QueryDocument) ParseWithDescriptions(queryString string) error {
 	l := lexer.Get(queryString)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -456,7 +456,7 @@ func (s *Schema) ResolveTypes() error {
 		t, ok := s.Types[name]
 		if !ok {
 			if !ok {
-				return qerrors.Errorf("type %q not found", name)
+				return qerrors.New("type %q not found", name)
 			}
 		}
 		s.EntryPoints[key] = t
@@ -470,11 +470,11 @@ func (s *Schema) ResolveTypes() error {
 		for i, intfName := range obj.InterfaceNames {
 			t, ok := s.Types[intfName]
 			if !ok {
-				return qerrors.Errorf("interface %q not found", intfName)
+				return qerrors.New("interface %q not found", intfName)
 			}
 			intf, ok := t.(*Interface)
 			if !ok {
-				return qerrors.Errorf("type %q is not an interface", intfName)
+				return qerrors.New("type %q is not an interface", intfName)
 			}
 			obj.Interfaces[i] = intf
 			intf.PossibleTypes = append(intf.PossibleTypes, obj)
@@ -485,11 +485,11 @@ func (s *Schema) ResolveTypes() error {
 		for i, name := range union.TypeNames {
 			t, ok := s.Types[name]
 			if !ok {
-				return qerrors.Errorf("object type %q not found", name)
+				return qerrors.New("object type %q not found", name)
 			}
 			obj, ok := t.(*Object)
 			if !ok {
-				return qerrors.Errorf("type %q is not an object", name)
+				return qerrors.New("type %q is not an object", name)
 			}
 			union.PossibleTypes[i] = obj
 		}
@@ -741,11 +741,11 @@ func resolveDirectives(s *Schema, directives DirectiveList) error {
 		dirName := d.Name
 		dd, ok := s.DeclaredDirectives[dirName]
 		if !ok {
-			return qerrors.Errorf("directive %q not found", dirName)
+			return qerrors.New("directive %q not found", dirName)
 		}
 		for _, arg := range d.Args {
 			if dd.Args.Get(arg.Name) == nil {
-				return qerrors.Errorf("invalid argument %q for directive %q", arg.Name, dirName)
+				return qerrors.New("invalid argument %q for directive %q", arg.Name, dirName)
 			}
 		}
 		for _, arg := range dd.Args {

--- a/schema/types.go
+++ b/schema/types.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"github.com/chirino/graphql/internal/lexer"
 	"github.com/chirino/graphql/qerrors"
+	uperrors "github.com/graph-gophers/graphql-go/errors"
 )
 
 func DeepestType(t Type) Type {
@@ -66,9 +67,9 @@ func ResolveType(t Type, resolver Resolver) (Type, *qerrors.Error) {
 	case *TypeName:
 		refT := resolver(t.Name)
 		if refT == nil {
-			err := qerrors.Errorf("Unknown type %q.", t.Name)
+			err := qerrors.New("Unknown type %q.", t.Name)
 			err.Rule = "KnownTypeNames"
-			err.Locations = []qerrors.Location{t.NameLoc}
+			err.Locations = []uperrors.Location{t.NameLoc}
 			return nil, err
 		}
 		return refT, nil

--- a/schema/values.go
+++ b/schema/values.go
@@ -4,16 +4,16 @@ import (
 	"encoding/json"
 
 	"github.com/chirino/graphql/internal/lexer"
-	"github.com/chirino/graphql/qerrors"
+	uperrors "github.com/graph-gophers/graphql-go/errors"
 )
 
 // http://facebook.github.io/graphql/draft/#InputValueDefinition
 type InputValue struct {
-	Loc        qerrors.Location
+	Loc        uperrors.Location
 	Name       string
 	NameLoc    Location
 	Type       Type
-	TypeLoc    qerrors.Location
+	TypeLoc    uperrors.Location
 	Default    Literal
 	Desc       Description
 	Directives DirectiveList


### PR DESCRIPTION
An attempt to fix the issue: https://github.com/aerogear/graphql-link/issues/41. 
Based on discussions in PR: https://github.com/aerogear/graphql-link/pull/57.

## Checklist of Imports
Following is a list of imports that `graphql-link` uses from this fork of `graphql`.

I have planned to work on one package at a time and update this checklist as soon as that package is successfully converted to make use of the upstream GraphQL repo.

- [x] "github.com/chirino/graphql"
- [ ] "github.com/chirino/graphql/schema"
- [x] "github.com/chirino/graphql/qerrors"
- [x] "github.com/chirino/graphql/graphiql"                    (Entirely new package, no change needed)
- [ ] "github.com/chirino/graphql/httpgql"
- [ ] "github.com/chirino/graphql/resolvers"
- [ ] "github.com/chirino/graphql/exec"
- [x] "github.com/chirino/graphql/customtypes"             (Not directly used by `graphql-link`)

## Further comments

The commit currently attached to this PR makes the `"github.com/chirino/graphql/qerrors"` package to import and use the `"github.com/graph-gophers/graphql-go/errors"` package of upstream repo by making some changes in the relevant files.

Once this commit change gets approved, I'll proceed to work on any of the remaining packages from the checklist above, by adding further commits to this PR itself.

**If there is any fault in my approach then please let me know, I would be happy to make the necessary changes according to the requirements.**